### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A simple Model Context Protocol (MCP) server for generating memes using the ImgFlip API. This server enables AI models and tools to generate meme images from user prompts.
 
+<a href="https://glama.ai/mcp/servers/d316l4kyh7">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/d316l4kyh7/badge" alt="Meme Server MCP server" />
+</a>
+
 ## Tools
 
 The server implements the following a single tool called `generateMeme`.


### PR DESCRIPTION
This PR adds a badge for the [Meme MCP Server](https://glama.ai/mcp/servers/d316l4kyh7) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/d316l4kyh7">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/d316l4kyh7/badge" alt="Meme Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.